### PR TITLE
To prevent SQL injection, allow MiddleKit queries to be made with parms passed separately

### DIFF
--- a/MiddleKit/Run/MySQLObjectStore.py
+++ b/MiddleKit/Run/MySQLObjectStore.py
@@ -91,9 +91,9 @@ class MySQLObjectStore(SQLObjectStore):
     def dbapiModule(self):
         return MySQLdb
 
-    def _executeSQL(self, cur, sql):
+    def _executeSQL(self, cur, sql, clausesArgs=None):
         try:
-            cur.execute(sql)
+            cur.execute(sql, clausesArgs)
         except MySQLdb.Warning:
             if not self.setting('IgnoreSQLWarnings', False):
                 raise

--- a/MiddleKit/Run/PostgreSQLObjectStore.py
+++ b/MiddleKit/Run/PostgreSQLObjectStore.py
@@ -75,9 +75,9 @@ class PostgreSQLObjectStore(SQLObjectStore):
     def dbapiModule(self):
         return dbi
 
-    def _executeSQL(self, cur, sql):
+    def _executeSQL(self, cur, sql, clausesArgs=None):
         try:
-            cur.execute(sql)
+            cur.execute(sql, clausesArgs)
         except Warning:
             if not self.setting('IgnoreSQLWarnings', False):
                 raise

--- a/MiddleKit/Run/SQLObjectStore.py
+++ b/MiddleKit/Run/SQLObjectStore.py
@@ -391,7 +391,7 @@ class SQLObjectStore(ObjectStore):
                 clauses = 'where %s=%d' % (klass.sqlSerialColumnName(), serialNum)
             if self._markDeletes:
                 clauses = self.addDeletedToClauses(clauses)
-            conn, cur = self.executeSQL(fetchSQLStart + clauses + ';', commit=False, clausesArgs=clausesArgs)
+            conn, cur = self.executeSQL(fetchSQLStart + clauses + ';', clausesArgs=clausesArgs)
             try:
                 for row in cur.fetchall():
                     serialNum = row[0]

--- a/MiddleKit/Run/SQLObjectStore.py
+++ b/MiddleKit/Run/SQLObjectStore.py
@@ -348,7 +348,7 @@ class SQLObjectStore(ObjectStore):
             return objects[0]
 
     def fetchObjectsOfClass(self, aClass,
-            clauses='', isDeep=True, refreshAttrs=True, serialNum=None):
+            clauses='', isDeep=True, refreshAttrs=True, serialNum=None, clausesArgs=None):
         """Fetch a list of objects of a specific class.
 
         The list may be empty if no objects are found.
@@ -379,7 +379,7 @@ class SQLObjectStore(ObjectStore):
         if isDeep:
             for subklass in klass.subklasses():
                 deepObjs.extend(self.fetchObjectsOfClass(
-                    subklass, clauses, isDeep, refreshAttrs, serialNum))
+                    subklass, clauses, isDeep, refreshAttrs, serialNum, clausesArgs))
 
         # Now get objects of this exact class
         objs = []
@@ -391,7 +391,7 @@ class SQLObjectStore(ObjectStore):
                 clauses = 'where %s=%d' % (klass.sqlSerialColumnName(), serialNum)
             if self._markDeletes:
                 clauses = self.addDeletedToClauses(clauses)
-            conn, cur = self.executeSQL(fetchSQLStart + clauses + ';')
+            conn, cur = self.executeSQL(fetchSQLStart + clauses + ';', commit=False, clausesArgs=clausesArgs)
             try:
                 for row in cur.fetchall():
                     serialNum = row[0]
@@ -429,7 +429,7 @@ class SQLObjectStore(ObjectStore):
 
     ## Self utility for SQL, connections, cursors, etc. ##
 
-    def executeSQL(self, sql, connection=None, commit=False):
+    def executeSQL(self, sql, connection=None, commit=False, clausesArgs=None):
         """Execute the given SQL.
 
         This will connect to the database for the first time if necessary.
@@ -450,18 +450,18 @@ class SQLObjectStore(ObjectStore):
             self._sqlEcho.write('SQL %04i. %s %s\n' % (self._sqlCount, timestamp, sql))
             self._sqlEcho.flush()
         conn, cur = self.connectionAndCursor(connection)
-        self._executeSQL(cur, sql)
+        self._executeSQL(cur, sql, clausesArgs)
         if commit:
             conn.commit()
         return conn, cur
 
-    def _executeSQL(self, cur, sql):
+    def _executeSQL(self, cur, sql, clausesArgs=None):
         """Invoke execute on the cursor with the given SQL.
 
         This is a hook for subclasses that wish to influence this event.
         Invoked by executeSQL().
         """
-        cur.execute(sql)
+        cur.execute(sql, clausesArgs)
 
     def executeSQLTransaction(self, transaction, connection=None, commit=True):
         """Execute the given sequence of SQL statements and commit as transaction."""

--- a/MiddleKit/Run/SQLiteObjectStore.py
+++ b/MiddleKit/Run/SQLiteObjectStore.py
@@ -26,9 +26,9 @@ class SQLiteObjectStore(SQLObjectStore):
     def dbVersion(self):
         return "SQLite %s" % sqlite.sqlite_version
 
-    def _executeSQL(self, cur, sql):
+    def _executeSQL(self, cur, sql, clausesArgs=None):
         try:
-            cur.execute(sql)
+            cur.execute(sql, clausesArgs)
         except sqlite.Warning:
             if not self.setting('IgnoreSQLWarnings', False):
                 raise


### PR DESCRIPTION
Recently we audited an internal Webware app for security.  We found that there is no mechanism in MiddleKit to pass user-submitted args separately.  Due to this, our approach had been to use string concatenation to build queries - however, this is vulnerable to SQL injection attacks.

We implemented this improvement which supports passing separate arguments to Store.fetchObjectsOfClass(), so that it is possible to build queries safely.

We have tested under MySQL.