### PR TITLE
Fix for errors that call objRefSplit() for args

### DIFF
--- a/MiddleKit/Run/SQLObjectStore.py
+++ b/MiddleKit/Run/SQLObjectStore.py
@@ -635,7 +635,7 @@ class SQLObjectStore(ObjectStore):
         Invoked by fetchObjRef() if either the class or the object serial
         number is zero.
         """
-        raise ObjRefZeroSerialNumError(objRefSplit(objRef))
+        raise ObjRefZeroSerialNumError(*objRefSplit(objRef))
 
     def objRefDangles(self, objRef):
         """Raise dangling reference error.
@@ -647,7 +647,7 @@ class SQLObjectStore(ObjectStore):
         self.warning() and includes the objRef as decimal, hexadecimal
         and class:obj numbers.
         """
-        raise ObjRefDanglesError(objRefSplit(objRef))
+        raise ObjRefDanglesError(*objRefSplit(objRef))
 
 
     ## Special Cases ##


### PR DESCRIPTION
We recently upgraded from an old version of Webware to the current master.
We discovered that there are some bugs in two cases where objRefSplit() is called, and the results are used to raise an exception.  These bugs were not present in the old Webware version - they must have been introduced more recently.
This PR fixes both cases.  We searched but did not find other occurrences of this bug in MiddleKit.