### PR TITLE
 Fix dumpObjectStore to dump objects in a consistent order

### DIFF
--- a/MiddleKit/Run/SQLObjectStore.py
+++ b/MiddleKit/Run/SQLObjectStore.py
@@ -719,7 +719,7 @@ class SQLObjectStore(ObjectStore):
     def dumpObjectStore(self, out=None, progress=False):
         if out is None:
             out = sys.stdout
-        for klass in self.model().klasses().values():
+        for klass in sorted( self.model().klasses().values(), key=lambda a:a.name()):
             if progress:
                 sys.stderr.write(".")
             out.write('%s objects\n' % (klass.name()))

--- a/MiddleKit/Tests/MKDump.mkmodel/Samples.csv
+++ b/MiddleKit/Tests/MKDump.mkmodel/Samples.csv
@@ -2,15 +2,15 @@ Bar objects
 barNonstandardId,name
 3,string containing spaces
 
+Baz objects
+bazNonstandardId,name,priority
+4,"string containing 'lots'' of ""quotes""
+and a newline and	a tab",10
+
 Foo objects
 fooNonstandardId,text,bar,fruit,num,isValid
 5,hello,Bar.3,apple,5,1
 6,,Baz.4,banana,,0
 7,,,banana,,0
-
-Baz objects
-bazNonstandardId,name,priority
-4,"string containing 'lots'' of ""quotes""
-and a newline and	a tab",10
 
 

--- a/MiddleKit/Tests/MKDump.mkmodel/TestSamples.py
+++ b/MiddleKit/Tests/MKDump.mkmodel/TestSamples.py
@@ -4,9 +4,10 @@ def test(store):
     with open('Dump.csv', 'w') as samples:
         store.dumpObjectStore(samples)
 
-    command = 'diff -u ../MKDump.mkmodel/Samples.csv Dump.csv'
+    command = 'diff -uZ ../MKDump.mkmodel/Samples.csv Dump.csv'
     print command
     retval = os.system(command)
-    retval >>= 8  # upper byte is the return code
+    if os.name=='posix':
+        retval >>= 8  # upper byte is the return code
 
     assert retval == 0


### PR DESCRIPTION
bei den Arbeiten an middlekit3 ist aufgefallen dass ein Test-Case vermutlich schon länger immer "ok" war.

Original:
https://patch-diff.githubusercontent.com/raw/nlgio/w4py3-middlekit/pull/6.diff

Die Änderung ist eigentlich nicht richtig perfekt weil nur zugunsten des Test-Case sortiert wird.
